### PR TITLE
Fixes broken link for Intro to Digital Currencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repository contains links to resources that have been important parts of ou
 
 ### Courses
 
-* [Introduction to Digital Currencies](https://digitalcurrency.unic.ac.cy/free-introductory-mooc/), by Andreas Antonopoulos and Antonis Polemitis.
+* [Introduction to Digital Currencies](https://www.youtube.com/playlist?list=PL68lGg7SjGZCfaCmsW0fBAJufcMgT8taZ), by Andreas Antonopoulos and Antonis Polemitis.
 
 ## [Community Management](https://en.wikipedia.org/wiki/Community_Management)
 


### PR DESCRIPTION
Link for "Intro to Digital Currencies" now redirects to YouTube playlist instead of 404.